### PR TITLE
(misc) allow attempts to dupe register metrics

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -20,7 +20,7 @@ var srvmiss = prometheus.NewCounterVec(prometheus.CounterOpts{
 }, []string{"identity"})
 
 func init() {
-	prometheus.MustRegister(srvctr)
-	prometheus.MustRegister(srvhit)
-	prometheus.MustRegister(srvmiss)
+	prometheus.Register(srvctr)
+	prometheus.Register(srvhit)
+	prometheus.Register(srvmiss)
 }


### PR DESCRIPTION
This is likely to happen due to multiple projects importing